### PR TITLE
Add python3 shebang-line to the script.

### DIFF
--- a/wig.py
+++ b/wig.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import json, pprint, os, time, queue, sys
 import argparse
 from collections import defaultdict, Counter


### PR DESCRIPTION
This allows direct execution of the script if python3 has been correctly
setup in the environment, while providing a clean exit if it hasn't.

Currently, direct execution of the script will use the default
interpreter of the environment, likely bash, with unpredictable results.