### PR TITLE
Only append '.json' to output file name if it is not already present

### DIFF
--- a/wig/classes/output.py
+++ b/wig/classes/output.py
@@ -96,10 +96,9 @@ class OutputJSON(Output):
 		})
 
 	def write_file(self):
-		file_name = self.options['write_file']
-		file_name = file_name if re.search(r'\.json\s*$', file_name) else file_name + '.json'
-		with open(file_name, 'w') as fh:
-			fh.write(json.dumps(self.json_data, sort_keys=True, indent=4, separators=(',', ': ')))
+                file_name = re.sub('(\.json)?\s*$', '', self.options['write_file']) + '.json'
+                with open(file_name, 'w') as fh:
+                    fh.write(json.dumps(self.json_data, sort_keys=True, indent=4, separators=(',', ': ')))
 
 
 class OutputPrinter(Output):

--- a/wig/classes/output.py
+++ b/wig/classes/output.py
@@ -97,7 +97,8 @@ class OutputJSON(Output):
 
 	def write_file(self):
 		file_name = self.options['write_file']
-		with open(file_name+ '.json', 'w') as fh:
+		file_name = file_name if re.search(r'\.json\s*$', file_name) else file_name + '.json'
+		with open(file_name, 'w') as fh:
 			fh.write(json.dumps(self.json_data, sort_keys=True, indent=4, separators=(',', ': ')))
 
 


### PR DESCRIPTION
`python wig.py www.beatboxchad.com -w ~/foo.json` created a file named ~/foo.json.json. Now that's fixed.