### PR TITLE
optionally allow to trust insecure certificates

### DIFF
--- a/wig/classes/request2.py
+++ b/wig/classes/request2.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import hashlib
 import re
+import ssl
 import string
 import random
 import urllib.request
@@ -217,6 +218,7 @@ class Requester:
 		self.threads = options['threads']
 		self.proxy = options['proxy']
 		self.user_agent = options['user_agent']
+		self.insecure = options['insecure']
 
 		self.data = data
 		self.cache = data['cache']
@@ -242,6 +244,12 @@ class Requester:
 
 		if redirect_handler:
 			args.append(RedirectHandler)
+
+		if self.insecure == True:
+			ctx = ssl.create_default_context()
+			ctx.check_hostname = False
+			ctx.verify_mode = ssl.CERT_NONE
+			args.append(urllib.request.HTTPSHandler(context=ctx))
 		
 		opener = urllib.request.build_opener(*args)
 		opener.addheaders = [('User-agent', self.user_agent)]

--- a/wig/wig.py
+++ b/wig/wig.py
@@ -69,6 +69,7 @@ class Wig(object):
 			'user_agent': args.user_agent,
 			'proxy': args.proxy,
 			'verbosity': args.verbosity,
+			'insecure': args.insecure,
 			'threads': 10,
 			'batch_size': 20,
 			'run_all': args.run_all,
@@ -326,6 +327,9 @@ def parse_args(url=None):
 
 	parser.add_argument('--verbosity', '-v', action='count', default=0,
 		help='Increase verbosity. Use multiple times for more info')
+
+	parser.add_argument('--insecure', '-i', action='store_true', dest='insecure', default=False,
+		help='Do not verify encrypted connections')
 
 	parser.add_argument('--proxy', dest='proxy', default=None,
 		help='Tunnel through a proxy (format: localhost:8080)')


### PR DESCRIPTION
When the remote server provides an invalid encryption certificate for the host, there should be an option allowing to ignore host mismatches.

In this case the flag `--insecure` or `-i` skips certificate validation.