### PR TITLE
add manpage based on --help output

### DIFF
--- a/wig.1
+++ b/wig.1
@@ -1,0 +1,66 @@
+.TH WIG "1" "May 2018" "wig 0.6" "User Commands"
+.SH NAME
+\fBwig\fR \- WebApp Information Gatherer
+.SH DESCRIPTION
+identify numerous Content Management Systems and other administrative applications
+.SH SYNOPSIS
+.B wig [\-h] [\-l INPUT_FILE] [\-q] [\-n STOP_AFTER] [\-a] [\-m] [\-u] [\-d]
+.IP
+.B [\-t THREADS] [\-\-no_cache_load] [\-\-no_cache_save] [\-N] [\-\-verbosity]
+.B [\-\-proxy PROXY] [\-w OUTPUT_FILE]
+.B <url>
+.SH OPTIONS
+.SS "Required arguments:"
+.TP
+.B url
+The url to scan e.g. http://example.com
+.SS "Optional arguments:"
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+show this help message and exit
+.TP
+\fB\-l\fR INPUT_FILE
+File with urls, one per line.
+.TP
+\fB\-q\fR
+Set wig to not prompt for user input during run
+.TP
+\fB\-n\fR STOP_AFTER
+Stop after this amount of CMSs have been detected. Default:
+1
+.TP
+\fB\-a\fR
+Do not stop after the first CMS is detected
+.TP
+\fB\-m\fR
+Try harder to find a match without making more requests
+.TP
+\fB\-u\fR
+User\-agent to use in the requests
+.TP
+\fB\-d\fR
+Disable the search for subdomains
+.TP
+\fB\-t\fR THREADS
+Number of threads to use
+.TP
+\fB\-\-no_cache_load\fR
+Do not load cached responses
+.TP
+\fB\-\-no_cache_save\fR
+Do not save the cache for later use
+.TP
+\fB\-N\fR
+Shortcut for \fB\-\-no_cache_load\fR and \fB\-\-no_cache_save\fR
+.TP
+\fB\-\-verbosity\fR, \fB\-v\fR
+Increase verbosity. Use multiple times for more info
+.TP
+\fB\-\-proxy\fR PROXY
+Tunnel through a proxy (format: localhost:8080)
+.TP
+\fB\-w\fR OUTPUT_FILE
+File to dump results into (JSON)
+.SH AUTHOR
+wig was developed by Jesper Kückelhahn, this manpage was made by Samuel Henrique <samueloph@debian.org> based on \fBwig --help\fR output and can be used by other projects as well.
+


### PR DESCRIPTION
As part of my gsoc project (http://deb.li/gsocpkgsec) i have chosen wig to be the first package to add on Debian. 
I ended up making this simple manpage that is made of the wig --help output, i think you'd like to add it to the project (and maybe receive further improvements from the community).

Oh, and the package is now on Debian unstable.

Thanks.