### PR TITLE
Return proper exit status on unknown host error

### DIFF
--- a/wig/wig.py
+++ b/wig/wig.py
@@ -116,7 +116,11 @@ class Wig(object):
 			if self.options['write_file'] is not None:
 				self.json_outputter.add_error(str(err))
 
-			return
+			if args.input_file is not None:
+				return
+
+			# exit with a non-zero status code to indicate failure
+			sys.exit(1)
 
 		if is_redirected:
 			if not self.options['quiet']:


### PR DESCRIPTION
Exit status is now 1 instead of 0 when an unknown host error occurs, making failures properly detectable in tests.